### PR TITLE
Show empty directories in solution pad

### DIFF
--- a/src/MonoDevelop.Dnx/MonoDevelop.Dnx/DnxProject.cs
+++ b/src/MonoDevelop.Dnx/MonoDevelop.Dnx/DnxProject.cs
@@ -81,11 +81,17 @@ namespace MonoDevelop.Dnx
 
 		void LoadFiles ()
 		{
+			// Add directories first, to make sure to show empty ones.
+			foreach (string directoryName in Directory.GetDirectories (BaseDirectory, "*.*", SearchOption.AllDirectories)) {
+				Items.Add (CreateFileProjectItem (directoryName));
+			}
+
 			foreach (string fileName in Directory.GetFiles (BaseDirectory, "*.*", SearchOption.AllDirectories)) {
 				if (IsSupportedProjectFileItem (fileName)) {
 					Items.Add (CreateFileProjectItem(fileName));
 				}
 			}
+
 			AddConfigurations ();
 		}
 


### PR DESCRIPTION
Showing empty directories in the solution pad is necessary especially when creating new projects that have an empty (and right now invisible) "wwwroot" directory.
